### PR TITLE
Switching back to bootstrap MD from angular MD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
   - stable
 
+before_script:
+  - npm install -g bower
+  - bower install
+
 before_deploy:
   - echo "building hydroid"
   - chmod +x ./travis/build.sh

--- a/app/app.js
+++ b/app/app.js
@@ -3,16 +3,14 @@
     "use strict";
     var mod = angular.module('hydroidApp', [
         'ngRoute',
-        'home',
-        'ngMaterial'
+        'home'
     ]);
 
-    mod.config(['$routeProvider', '$locationProvider', '$mdThemingProvider',
-        function ($routeProvider, $locationProvider, $mdThemingProvider) {
+    mod.config(['$routeProvider', '$locationProvider',
+        function ($routeProvider, $locationProvider) {
             $routeProvider.when('/', {template: '<hydroid-home></hydroid-home>'});
             $routeProvider.otherwise({redirectTo: '/'});
             $locationProvider.html5Mode(false);
-            $mdThemingProvider.theme('default')
-                .primaryPalette('light-blue');
+            $.material.init();
         }]);
 })();

--- a/app/components/home/home.html
+++ b/app/components/home/home.html
@@ -1,27 +1,32 @@
-<div layout="column">
-    <section layout="row">
-        <md-sidenav class="md-sidenav-left md-whiteframe-z2" md-component-id="left" md-is-locked-open="$mdMedia('gt-md')">
-            <md-toolbar class="md-theme-light-blue">
-                <h1 class="md-toolbar-tools">Search</h1>
-            </md-toolbar>
-            <md-content layout-padding>
-                <md-button ng-click="close()" class="md-primary" hide-gt-md>
-                    Close Search
-                </md-button>
-                <form>
-                    <md-input-container>
-                        <label for="testInput">Search</label>
-                        <input type="text" id="testInput"
-                               ng-model="data" md-autofocus>
-                    </md-input-container>
-                </form>
-            </md-content>
-        </md-sidenav>
-    <md-content flex layout-padding>
-        <div layout="column" layout-fill layout-align="top center">
-            Home body... Testing.
+<div class="row">
+    <div class="col-sm-3">
+        <div class="panel">
+            <div class="panel-body">
+                <h3>Hydroid Search</h3>
+                <div class="form-group is-empty">
+                    <input type="text" class="form-control col-sm-8" placeholder="Search">
+                    <span class="material-input"></span>
+                </div>
+                <div class="list-group">
+                    <div class="list-group-item">
+                        <!--<div class="row-action-primary">-->
+                        <!--<i class="material-icons">folder</i>-->
+                        <!--</div>-->
+                        <!--<div class="row-content">-->
+                        <!--<div class="least-content">15m</div>-->
+                        <!--<h4 class="list-group-item-heading">Tile with a label</h4>-->
+
+                        <!--<p class="list-group-item-text">Donec id elit non mi porta gravida at eget metus.</p>-->
+                        <!--</div>-->
+                    </div>
+                </div>
+            </div>
         </div>
-        <div flex></div>
-    </md-content>
-    </section>
+    </div>
+    <div class="col-sm-9">
+        <div class="panel">
+            <div class="panel-heading">Home Heading</div>
+            <div class="panel-body">Home body...</div>
+        </div>
+    </div>
 </div>

--- a/app/index.html
+++ b/app/index.html
@@ -10,10 +10,8 @@
     <!-- build:css lib/css/bootstrap.min.css -->
     <link href="../node_modules/bootstrap/dist/css/bootstrap.css" rel="stylesheet">
     <!-- endbuild -->
-    <!-- build:css lib/css/angular-material.css-->
-    <link rel="stylesheet" href="../node_modules/angular-material/angular-material.css">
-    <!-- endbuild -->
     <!-- build:css css/app.min.css -->
+    <link rel="stylesheet" href="../bower_components/bootstrap-material-design/dist/css/bootstrap-material-design.css">
     <link rel="stylesheet" href="css/app.header.footer.css">
     <link rel="stylesheet" href="css/app.css">
     <!-- endbuild -->
@@ -68,15 +66,15 @@
 <!-- build:js lib/js/jquery.min.js -->
 <script src="../node_modules/jquery/dist/jquery.js"></script>
 <!-- endbuild -->
+<!-- build:js lib/js/bootstrap.min.js -->
+<script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+<!-- endbuild -->
+<!-- build:js lib/js/material.min.js -->
+<script src="../bower_components/bootstrap-material-design/dist/js/material.js"></script>
+<!-- endbuild -->
 <!-- build:js lib/js/angular.min.js -->
 <script src="../node_modules/angular/angular.js"></script>
 <!-- endbuild -->
-<!-- build:js lib/js/angular-material.js -->
-<script src="../node_modules/angular-aria/angular-aria.js"></script>
-<script src="../node_modules/angular-animate/angular-animate.js"></script>
-<script src="../node_modules/angular-material/angular-material.js"></script>
-<!-- endbuild -->
-
 <!-- build:js lib/js/angular-route.min.js -->
 <script src="../node_modules/angular-route/angular-route.js"></script>
 <!-- endbuild -->

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "hydroid-client",
+  "version": "0.0.0",
+  "homepage": "https://github.com/GeoscienceAustralia/hydroid-client",
+  "authors": [
+    "Geoscience Australia"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "bootstrap-material-design": "~0.5.7"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "angular-aria":"^1.4.7",
     "angular-ui-bootstrap": "^1.0.0",
     "bootstrap": "^3.3.6",
-    "jquery": "^1.11.3",
-    "angular-material": "^1.0.2"
+    "jquery": "^1.11.3"
   }
 }


### PR DESCRIPTION
This is due to compatibility issues around IE 9 and the angular-material-design library.

Bootstrap material design has good compatibility with IE9 but is only available via bower. 

Added bower install commands to travis scripts.