### PR TITLE
Reset search + Filter by facet

### DIFF
--- a/app/components/search/search-related.html
+++ b/app/components/search/search-related.html
@@ -27,7 +27,7 @@
 <script type="text/ng-template" id="menuTemplateInit">
     <div class="row facet">
         <div class="col-xs-12">
-            <a href="">
+            <a href="" ng-click="filterByFacet(menuItem.nodeLabel)">
                 {{ menuItem.nodeLabel }}&nbsp;
             </a>
         </div>

--- a/app/components/search/search-related.js
+++ b/app/components/search/search-related.js
@@ -35,7 +35,7 @@
 
                 $scope.filterByFacet = function(facet) {
                     $http.get($scope.solrUrl + '/' + $scope.solrCollection +
-                        '/select?q=*&facet=true&facet.field=label_s&facet.mincount=1&fq=' + getChildrenFacets(facet) + '&wt=json')
+                        '/select?q=' + getChildrenFacets(facet) + '&facet=true&facet.field=label_s&facet.mincount=1&wt=json')
                         .then(function (response) {
                             console.log(response.data);
                             $timeout(function () {
@@ -62,7 +62,7 @@
                     if (facets != '') {
                         facets = facets + ' OR ';
                     }
-                    facets = facets + 'label:' + menuItem.nodeLabel;
+                    facets = facets + 'label:"' + menuItem.nodeLabel + '"';
                     if (menuItem.children) {
                         for (var i=0; i < menuItem.children.length; i++) {
                             facets = getAllChildrenFacets(menuItem.children[i], facets);
@@ -77,7 +77,7 @@
                     if (menuItem) {
                         return getAllChildrenFacets(menuItem, '');
                     }
-                    return 'label:' + facet;
+                    return 'label:"' + facet + '"';
                 };
 
             }]

--- a/app/components/search/search-results.html
+++ b/app/components/search/search-results.html
@@ -100,13 +100,8 @@
     <div ng-show="(results.docs | filter: { docType: 'IMAGE' }).length > 0">
         <h4>Images</h4>
         <div class="row">
-<<<<<<< HEAD
             <div class="col-xs-6 col-sm-4 col-lg-2 cartBtnColors" ng-repeat="result in results.docs | filter: { docType: 'IMAGE' }">
-                <img src="{{getDownloadImageUrl(result.about)}}" alt="{{ result.title }}" class="img-thumbnail img-responsive">
-=======
-            <div class="col-xs-6 col-sm-4 col-lg-2" ng-repeat="result in results.docs | filter: { docType: 'IMAGE' }">
                 <img ng-src="{{getDownloadImageUrl(result.about)}}" alt="{{ result.title }}" class="img-thumbnail img-responsive">
->>>>>>> refs/remotes/origin/master
             </div>
         </div>
     </div>

--- a/app/components/search/search.html
+++ b/app/components/search/search.html
@@ -4,7 +4,7 @@
             <input type="text" class="form-control" placeholder="What is your interest ?" ng-model="query">
         </div>
         <div class="col-lg-2 visible-lg searchBoxBtnContainer">
-            <button type="button" class="btn btn-lg btn-primary" style="width:100%">Search</button>
+            <button type="button" ng-click="resetSearch()" class="btn btn-lg btn-primary btn-group-justified">Reset</button>
         </div>
         <!-- /input-group -->
     </div><!-- /.col-lg-4 -->

--- a/app/components/search/search.js
+++ b/app/components/search/search.js
@@ -29,7 +29,7 @@
                             },200)
                         }
                     } else if (oldVal) {
-                        resetSearch();
+                        $scope.resetSearch();
                     }
                 });
 
@@ -51,7 +51,10 @@
                             });
                 };
 
-                var resetSearch = function() {
+                $scope.resetSearch = function() {
+                    if ($scope.query) {
+                        $scope.query = null;
+                    }
                     $scope.results = [];
                     SearchServices.resetMenuCounters($scope.menuItems);
                 };


### PR DESCRIPTION
- Using solr facet query (fq) was returning all documents, even those with labels/facets not included in the query params. Replaced fq with q and enclosed param values with double quotes to prevent partial matches from being included in the results.

- Added reset search button to clean results and reset menus

- Added filter by facet to the top level menus (when no results are present)
