### PR TITLE
Refine via query string search

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -13,7 +13,7 @@
 
     mod.config(['$routeProvider', '$locationProvider',
         function ($routeProvider, $locationProvider) {
-            $routeProvider.when('/', {template: '<hydroid-home></hydroid-home>'});
+            $routeProvider.when('/', {template: '<hydroid-home></hydroid-home>',reloadOnSearch:false});
             $routeProvider.when('/enhancer', {template: '<hydroid-enhancer></hydroid-enhancer>'});
             $routeProvider.when('/cart', {template: '<shopping-cart></shopping-cart>'});
             $routeProvider.otherwise({redirectTo: '/'});

--- a/app/components/search/search-related.html
+++ b/app/components/search/search-related.html
@@ -9,29 +9,23 @@
     </ul>
 </div>
 <script type="text/ng-template" id="menuTemplate">
-    <div class="row facet searchRelatedButton" ng-click="filterByFacet(menuItem.nodeLabel)" ng-if="!results.docs || results.docs.length == 0 || menuItem.count > 0">
-        <div class="col-xs-9">
-            <h5>
-                <a href="">
-                    {{ menuItem.nodeLabel }}&nbsp;
-                </a>
-            </h5>
-        </div>
+    <div class="row facet" ng-if="!results.docs || results.docs.length == 0 || menuItem.count > 0" ng-class="{searchRelatedButton: menuItem.nodeType == null}">
+        <a href="#/?facet={{menuItem.nodeLabel.split(' ').join('_')}}" class="col-xs-9">
+            <h5>{{ menuItem.nodeLabel }}&nbsp;</h5>
+        </a>
         <div class="col-xs-3 text-right">
             <span class="badge" style="background-color: white; color: #006983;" ng-if="menuItem.count">{{ menuItem.count }}</span>
         </div>
     </div>
-    <ul ng-if="menuItem.children" >
-        <li ng-repeat="menuItem in menuItem.children" ng-include="'menuTemplate'" ng-if="!results.docs || results.docs.length == 0 || menuItem.count > 0">
+    <ul ng-if="menuItem.children">
+        <li ng-repeat="menuItem in menuItem.children" ng-include="'menuTemplate'" ng-if="!results.docs || results.docs.length == 0 || menuItem.count > 0" style="background-color: white">
         </li>
     </ul>
 </script>
 <script type="text/ng-template" id="menuTemplateInit">
-    <div class="row facet" ng-click="filterByFacet(menuItem.nodeLabel)">
-        <div class="col-xs-12 searchRelatedButton" ng-click="filterByFacet(menuItem.nodeLabel)">
-            <h5>
-                <a href="">{{ menuItem.nodeLabel }}&nbsp; <span class="glyphicon glyphicon-menu-right pull-right"></span></a>
-            </h5>
-        </div>
+    <div class="row facet">
+        <a href="#/?facet={{menuItem.nodeLabel.split(' ').join('_')}}" class="col-xs-12 searchRelatedButton">
+            <h5>{{ menuItem.nodeLabel }}&nbsp; <span class="glyphicon glyphicon-menu-right pull-right"></span></h5>
+        </a>
     </div>
 </script>

--- a/app/components/search/search.js
+++ b/app/components/search/search.js
@@ -4,7 +4,7 @@
 
     var module = angular.module('search', ['search-services']);
 
-    module.directive('hydroidSearch', ['$http', '$timeout', 'SearchServices', function ($http, $timeout, SearchServices) {
+    module.directive('hydroidSearch', ['$http', '$timeout', 'SearchServices','$location', function ($http, $timeout, SearchServices, $location) {
         return {
             restrict: 'E',
             scope: {
@@ -55,6 +55,7 @@
                     if ($scope.query) {
                         $scope.query = null;
                     }
+                    $location.search('facet',null);
                     $scope.results = [];
                     SearchServices.resetMenuCounters($scope.menuItems);
                 };


### PR DESCRIPTION
Moved facet refine to get data from query string search and changed the home route to not reload on search path change.

This allowed for users to retain history of refinements and use native browser navigations (back/forward) buttons for each refinement.