### PR TITLE
Add download button

### DIFF
--- a/app/components/cart/cart.js
+++ b/app/components/cart/cart.js
@@ -15,7 +15,7 @@
                 $scope.removeItemFromCart = function(item) {
                     var index = $scope.cartList.indexOf(item);
                     $scope.cartList.splice(index, 1);
-                }
+                };
 
                 $scope.getDownloadUrl = function(item) {
                     return item.docUrl;

--- a/app/components/search/search-related.spec.js
+++ b/app/components/search/search-related.spec.js
@@ -1,0 +1,57 @@
+/* global describe, beforeEach, it */
+
+describe('hydroid search related tests', function () {
+    var $compile,
+        $rootScope,
+        $timeout,
+        $filter,
+        $location,
+        $httpBackend;
+
+    angular.module('mockSearchRelatedApp', ['ngMock', 'search-related','config']);
+
+    beforeEach(module('components/search/search-related.html','components/search/search-related-item.html'));
+    // Load the myApp module, which contains the service
+    beforeEach(module('mockSearchRelatedApp'));
+
+    // Store references to $rootScope and $compile
+    // so they are available to all tests in this describe block
+    beforeEach(inject(function($injector,_$compile_, _$rootScope_,_$timeout_, _$filter_,_$location_,_$httpBackend_) {
+        // The injector unwraps the underscores (_) from around the parameter names when matching
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        $timeout = _$timeout_;
+        $filter = _$filter_;
+        $location = _$location_;
+        $httpBackend = _$httpBackend_;
+        $httpBackend.when('GET','/solr/hydroid/select?q=docType:DOCUMENT AND (label:"testing123")&rows=5&start=5&facet=true&facet.field=label_s&facet.mincount=1&wt=json&hl=true&hl.simple.pre=<b>&hl.simple.post=</b>&hl.snippets=5&hl.fl=content&fl=extracted-from,concept,docUrl,about,imgThumb,docType,label,title,selectionContext,created,creator')
+            .respond(JSON.stringify({ "responseHeader":{"status":0,"QTime":1,"params":{"facet":"true","facet.mincount":"1","json":"","start":"0","q":"docType:IMAGE AND \"*thiswontbthe*\"","facet.field":"label_s","wt":"json","rows":"6"}},"response":{"numFound":0,"start":0,"docs":[{},{}]},"facet_counts":{"facet_queries":{},"facet_fields":{"label_s":[]},"facet_dates":{},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}} }));
+        var menuData = readJSON('app/data/menu.json');
+        $rootScope.menuItems = menuData;
+        $httpBackend.when('GET','/data/menu.json')
+            .respond(JSON.stringify(menuData));
+    }));
+
+    it('Should be able to render menu when hasResults is true', function () {
+        $rootScope.hasSearchResults = true;
+        var element = $compile('<hydroid-search-related menu-items="menuItems" has-results="hasSearchResults"' +
+        '></hydroid-search-related>')($rootScope);
+        $rootScope.$digest();
+        var directiveScope = element.isolateScope();
+        expect(directiveScope).not.toBe(null);
+        directiveScope.$digest();
+        expect(directiveScope.hasResults).toBe(true);
+    });
+
+    it('Should be able to render menu when hasResults is false', function () {
+        $rootScope.hasSearchResults = false;
+        var element = $compile('<hydroid-search-related menu-items="menuItems" has-results="hasSearchResults"' +
+            '></hydroid-search-related>')($rootScope);
+        $rootScope.$digest();
+        var directiveScope = element.isolateScope();
+        expect(directiveScope).not.toBe(null);
+        directiveScope.$digest();
+        expect(directiveScope.hasResults).toBe(false);
+    });
+
+});

--- a/app/components/search/search-results.html
+++ b/app/components/search/search-results.html
@@ -26,8 +26,8 @@
             <button class="btn btn-primary" ng-click="goToDownloadUrl(result.docUrl)" title="Download RDF"><span class="glyphicon glyphicon-download-alt"></span></button>
             <button class="btn btn-primary" title="{{isItemInCart(result.about) ? 'Remove from cart' : 'Add to cart'}}"
                     ng-click="addToCart(result)">
-                <div ng-if="!isItemInCart(result.about)"><span class="glyphicon glyphicon-shopping-cart"></span><span class="glyphicon glyphicon-plus-sign"></span></div>
-                <div ng-if="isItemInCart(result.about)"><span class="glyphicon glyphicon-shopping-cart"></span><span class="glyphicon glyphicon-ok" ng-show="isItemInCart(result.about)"></span></div>
+                <span ng-if="!isItemInCart(result.about)"><span class="glyphicon glyphicon-shopping-cart"></span><span class="glyphicon glyphicon-plus-sign"></span></span>
+                <span ng-if="isItemInCart(result.about)"><span class="glyphicon glyphicon-shopping-cart"></span><span class="glyphicon glyphicon-ok" ng-show="isItemInCart(result.about)"></span></span>
             </button>
         </div>
     </div>

--- a/app/components/search/search-results.html
+++ b/app/components/search/search-results.html
@@ -14,19 +14,20 @@
         {{ sectionTitle }}
     </h4>
     <div class="row" ng-show="showResults"  ng-class="{'animate-fade-out': isLoading, 'animate-fade-in': !isLoading}">
-        <div class="col-sm-10">
+        <div class="col-sm-9">
             <h4 ng-bind="result.title"></h4>
             <h6 ng-show="result.created"><b>Created on: </b>{{ result.created | date }}</h6>
             <h6 ng-show="result.creator"><b>Authors: </b>{{ result.creator }}</h6>
             <br/>
             <p ng-bind-html="result.selectionContext | hydroidTruncateTextPreview: query:facetsArray | hydroidQueryResultsFilter: query | hydroidFacetsResultsFilter: facetsArray | hydroidRelateHighlights: result.about:highlights | hydroidTrustedText"></p>
         </div>
-        <div class="col-sm-2 text-right cartBtnStyles">
-            <button class="btn btn-primary btn-sm" ng-click="goToDownloadUrl(result.docUrl)">RDF Download</button>
-            <button class="btn btn-primary btn-sm"
+        <div class="col-sm-3 text-right cartBtnStyles">
+            <button class="btn btn-primary" ng-click="downloadOriginal(result)" title="Download File"><span class="glyphicon glyphicon-folder-open"></span></button>
+            <button class="btn btn-primary" ng-click="goToDownloadUrl(result.docUrl)" title="Download RDF"><span class="glyphicon glyphicon-download-alt"></span></button>
+            <button class="btn btn-primary" title="{{isItemInCart(result.about) ? 'Remove from cart' : 'Add to cart'}}"
                     ng-click="addToCart(result)">
-                <div ng-if="!isItemInCart(result.about)">Add to cart</div>
-                <div ng-if="isItemInCart(result.about)">Added <span class="glyphicon glyphicon-ok" ng-show="isItemInCart(result.about)"></span></div>
+                <div ng-if="!isItemInCart(result.about)"><span class="glyphicon glyphicon-shopping-cart"></span><span class="glyphicon glyphicon-plus-sign"></span></div>
+                <div ng-if="isItemInCart(result.about)"><span class="glyphicon glyphicon-shopping-cart"></span><span class="glyphicon glyphicon-ok" ng-show="isItemInCart(result.about)"></span></div>
             </button>
         </div>
     </div>

--- a/app/components/search/search-results.js
+++ b/app/components/search/search-results.js
@@ -156,7 +156,11 @@
                 });
 
                 $scope.goToDownloadUrl = function(itemUrl) {
-                    location.href = itemUrl;
+                    window.open(itemUrl,'_blank');
+                };
+
+                $scope.downloadOriginal = function(item) {
+                    window.open("/api/downloads/documents/" + item.about,'_blank');
                 };
 ;
                 $scope.isItemInCart = function(urn) {
@@ -166,9 +170,16 @@
                     return false;
                 };
 
+                $scope.removeItemFromCart = function(item) {
+                    var index = $scope.cartItems.indexOf(item);
+                    $scope.cartItems.splice(index, 1);
+                };
+
                 $scope.addToCart = function(item) {
                     if (!$scope.isItemInCart(item.about)){
                         $scope.cartItems.push(item);
+                    } else {
+                        $scope.removeItemFromCart(item);
                     }
                 };
 

--- a/app/components/search/search-results.js
+++ b/app/components/search/search-results.js
@@ -162,7 +162,7 @@
                 $scope.downloadOriginal = function(item) {
                     window.open("/api/downloads/documents/" + item.about,'_blank');
                 };
-;
+
                 $scope.isItemInCart = function(urn) {
                     for(var i = 0; i < $scope.cartItems.length; i++) {
                         if (urn == $scope.cartItems[i].about) return true;
@@ -200,7 +200,7 @@
                         .then(function (result) {
                             $timeout(function () {
                                 $scope.documents.push.apply($scope.documents,result.docs);
-                            },10);
+                            });
                         });
                 };
 

--- a/app/components/search/search-results.spec.js
+++ b/app/components/search/search-results.spec.js
@@ -3,10 +3,7 @@
 describe('hydroid search results tests', function () {
     var $compile,
         $rootScope,
-        modalService,
         $timeout,
-        $httpBackend,
-        SearchServices,
         $filter,
         $location,
         $httpBackend;
@@ -24,20 +21,19 @@ describe('hydroid search results tests', function () {
         $compile = _$compile_;
         $rootScope = _$rootScope_;
         $timeout = _$timeout_;
-        $httpBackend = $injector.get('$httpBackend');
         $filter = _$filter_;
         $location = _$location_;
         $httpBackend = _$httpBackend_;
         $httpBackend.when('GET','/solr/hydroid/select?q=docType:DOCUMENT AND (label:"testing123")&rows=5&start=5&facet=true&facet.field=label_s&facet.mincount=1&wt=json&hl=true&hl.simple.pre=<b>&hl.simple.post=</b>&hl.snippets=5&hl.fl=content&fl=extracted-from,concept,docUrl,about,imgThumb,docType,label,title,selectionContext,created,creator')
             .respond(JSON.stringify({ "responseHeader":{"status":0,"QTime":1,"params":{"facet":"true","facet.mincount":"1","json":"","start":"0","q":"docType:IMAGE AND \"*thiswontbthe*\"","facet.field":"label_s","wt":"json","rows":"6"}},"response":{"numFound":0,"start":0,"docs":[{},{}]},"facet_counts":{"facet_queries":{},"facet_fields":{"label_s":[]},"facet_dates":{},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}} }));
+        var menuData = readJSON('app/data/menu.json');
         $httpBackend.when('GET','/data/menu.json')
-            .respond(JSON.stringify({}));
+            .respond(JSON.stringify(menuData));
+        $rootScope.menuItems = menuData;
     }));
 
     it('should be able to collect facet stats', function () {
         $location.search('query','fish');
-        var menuData = readJSON('app/data/menu.json');
-        $rootScope.menuItems = menuData;
         $rootScope.cartItems = [];
         $rootScope.documents = [{},{}];
         $rootScope.documentNumFound = 2;
@@ -91,8 +87,6 @@ describe('hydroid search results tests', function () {
     });
 
     it('Should process "nextPage" call correctly', function () {
-        var menuData = readJSON('app/data/menu.json');
-        $rootScope.menuItems = menuData;
         $rootScope.cartItems = [];
         $rootScope.documents = [{},{}];
         $rootScope.documentNumFound = 2;

--- a/app/components/search/search.spec.js
+++ b/app/components/search/search.spec.js
@@ -1,0 +1,42 @@
+/* global describe, beforeEach, it */
+
+describe('hydroid search related tests', function () {
+    var $compile,
+        $rootScope,
+        $timeout,
+        $filter,
+        $location,
+        $httpBackend;
+
+    angular.module('mockSearchApp', ['ngMock', 'search','config']);
+
+    beforeEach(module('components/search/search.html'));
+    // Load the myApp module, which contains the service
+    beforeEach(module('mockSearchApp'));
+
+    // Store references to $rootScope and $compile
+    // so they are available to all tests in this describe block
+    beforeEach(inject(function($injector,_$compile_, _$rootScope_,_$timeout_, _$filter_,_$location_,_$httpBackend_) {
+        // The injector unwraps the underscores (_) from around the parameter names when matching
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        $timeout = _$timeout_;
+        $filter = _$filter_;
+        $location = _$location_;
+        $httpBackend = _$httpBackend_;
+        $httpBackend.when('GET','/data/menu.json')
+            .respond(JSON.stringify({}));
+    }));
+
+    it('Should be able to render search', function () {
+        var menuData = readJSON('app/data/menu.json');
+        $rootScope.menuItems = menuData;
+        $rootScope.hasSearchResults = true;
+        var element = $compile('<hydroid-search></hydroid-search>')($rootScope);
+        $rootScope.$digest();
+        var directiveScope = element.isolateScope();
+        expect(directiveScope).not.toBe(null);
+        directiveScope.$digest();
+    });
+
+});

--- a/app/css/app.css
+++ b/app/css/app.css
@@ -129,7 +129,6 @@ li {
 .cartBtnStyles .btn.btn-primary:focus {
     background-color: #006983;
     border-radius: 0px;
-    width: 100px;
     margin-bottom: 10px;
     outline: none;
 }


### PR DESCRIPTION
Change result actions to add "Download" and "Download RDF" as well
improve the "add to cart" UI.

Now mainly uses symbols and title. This is to allow users to simply
view/download the original document as well as resultant enhanced RDF.

Eg,

![image](https://cloud.githubusercontent.com/assets/234642/15135304/efdabad8-16b7-11e6-87cb-61ee4b08d399.png)
